### PR TITLE
修复：避免全息信标格位冲突

### DIFF
--- a/data/items_vanilla.json
+++ b/data/items_vanilla.json
@@ -5910,7 +5910,7 @@
     "Description": "I蓄电器（满）",
     "IconPath": "Icons/ItemRecipe/accumulator-full",
     "IconTag": "mxdq",
-    "GridIndex": 2114,
+    "GridIndex": 2115,
     "StackSize": 50,
     "Type": 5,
     "PreTechOverride": 1511,

--- a/tests/test_item_grid.py
+++ b/tests/test_item_grid.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ITEM_FILES = [
+    ROOT / "data" / "items_vanilla.json",
+    ROOT / "data" / "items_mod.json",
+]
+MAX_PAGE = 5
+MAX_ROW = 7
+MAX_COLUMN = 17
+
+
+class ItemGridTest(unittest.TestCase):
+    def test_non_zero_item_grid_indices_are_unique_and_in_picker_bounds(self):
+        seen = {}
+        for path in ITEM_FILES:
+            with path.open(encoding="utf-8-sig") as handle:
+                for item in json.load(handle):
+                    grid_index = item["GridIndex"]
+                    if grid_index == 0:
+                        continue
+
+                    item_id = item["ID"]
+                    page = grid_index // 1000
+                    row = (grid_index - page * 1000) // 100
+                    column = grid_index % 100
+
+                    self.assertGreaterEqual(page, 1, f"{item_id} has invalid page in {grid_index}")
+                    self.assertLessEqual(page, MAX_PAGE, f"{item_id} has invalid page in {grid_index}")
+                    self.assertGreaterEqual(row, 1, f"{item_id} has invalid row in {grid_index}")
+                    self.assertLessEqual(row, MAX_ROW, f"{item_id} has invalid row in {grid_index}")
+                    self.assertGreaterEqual(column, 1, f"{item_id} has invalid column in {grid_index}")
+                    self.assertLessEqual(column, MAX_COLUMN, f"{item_id} has invalid column in {grid_index}")
+
+                    self.assertNotIn(
+                        grid_index,
+                        seen,
+                        f"{item_id} and {seen.get(grid_index)} share item GridIndex {grid_index}",
+                    )
+                    seen[grid_index] = item_id
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
原因：全息信标和蓄电器满共享 GridIndex=2114，原版 UIItemPicker 会在同一格覆盖物品，导致其中一个物品无法从矩阵选择。

实现：保留全息信标在 2114，将蓄电器满移到相邻空格 2115，并新增 item GridIndex 唯一性和边界测试。

验证：python3 -m unittest tests.test_item_grid；git diff --check。

影响：只调整物品矩阵位置，不改变配方、物品 ID 或存档数据。